### PR TITLE
Striped improvements

### DIFF
--- a/PrimeRust/solution_1/README.md
+++ b/PrimeRust/solution_1/README.md
@@ -36,14 +36,18 @@ Tested on a Ryzen 3900X, Rust 1.53, running on WSL2.
 
 This is as reported on `stdout`:
 ```
-mike-barber_byte-storage;18899;5.0000662804;1;algorithm=base,faithful=yes,bits=8
-mike-barber_bit-storage;12078;5.0003247261;1;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-rotate;14249;5.0003366470;1;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-striped;19021;5.0002198219;1;algorithm=base,faithful=yes,bits=1
-mike-barber_byte-storage;171065;5.0014705658;24;algorithm=base,faithful=yes,bits=8
-mike-barber_bit-storage;134961;5.0008754730;24;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-rotate;166345;5.0007843971;24;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-striped;190855;5.0008077621;24;algorithm=base,faithful=yes,bits=1
+mike-barber_byte-storage;18661;5.0000872612;1;algorithm=base,faithful=yes,bits=8
+mike-barber_bit-storage;12098;5.0002989769;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-rotate;14090;5.0002450943;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped;19205;5.0002722740;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped-blocks;21305;5.0001897812;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped-blocks-small;20338;5.0000920296;1;algorithm=base,faithful=yes,bits=1
+mike-barber_byte-storage;170552;5.0009374619;24;algorithm=base,faithful=yes,bits=8
+mike-barber_bit-storage;134112;5.0011000633;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-rotate;164057;5.0006699562;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped;191961;5.0007262230;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped-blocks;221099;5.0007972717;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped-blocks-small;224842;5.0006871223;24;algorithm=base,faithful=yes,bits=1
 ```
 
 We report more informative metrics to `stderr` too, but these don't go into the report, as recorded below.

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -768,7 +768,7 @@ fn run_implementation<T: 'static + FlagStorage + Send>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::primes::{PrimeValidator, BLOCK_SIZE_DEFAULT};
+    use crate::primes::PrimeValidator;
 
     #[test]
     fn sieve_known_correct_bits() {

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -330,7 +330,6 @@ pub mod primes {
     }
 
     impl<const N: usize> FlagStorage for FlagStorageBitVectorStripedBlocks<N> {
-        #[inline(always)]
         fn create_true(size: usize) -> Self {
             let num_blocks = size / Self::BLOCK_SIZE_BITS + (size % Self::BLOCK_SIZE_BITS).min(1);
             Self {

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -9,6 +9,8 @@ use std::{
 };
 use structopt::StructOpt;
 
+use crate::primes::FlagStorageBitVectorStripedBlocks;
+
 pub mod primes {
     use std::{collections::HashMap, time::Duration, usize};
 
@@ -538,6 +540,10 @@ struct CommandLineOptions {
     #[structopt(long)]
     bits_striped: bool,
 
+    /// Run variant that uses bit-level storage, using striped storage in blocks
+    #[structopt(long)]
+    bits_striped_blocks: bool,
+
     /// Run variant that uses byte-level storage
     #[structopt(long)]
     bytes: bool,
@@ -558,9 +564,15 @@ fn main() {
     };
 
     // run all implementations if no options are specified (default)
-    let run_all = [opt.bits, opt.bits_rotate, opt.bits_striped, opt.bytes]
-        .iter()
-        .all(|b| !*b);
+    let run_all = [
+        opt.bits,
+        opt.bits_rotate,
+        opt.bits_striped,
+        opt.bits_striped_blocks,
+        opt.bytes,
+    ]
+    .iter()
+    .all(|b| !*b);
 
     for threads in thread_options {
         if opt.bytes || run_all {
@@ -614,6 +626,21 @@ fn main() {
             for _ in 0..repetitions {
                 run_implementation::<FlagStorageBitVectorStriped>(
                     "bit-storage-striped",
+                    1,
+                    run_duration,
+                    threads,
+                    limit,
+                    opt.print,
+                );
+            }
+        }
+
+        if opt.bits_striped_blocks || run_all {
+            thread::sleep(Duration::from_secs(1));
+            print_header(threads, limit, run_duration);
+            for _ in 0..repetitions {
+                run_implementation::<FlagStorageBitVectorStripedBlocks>(
+                    "bit-storage-striped-blocks",
                     1,
                     run_duration,
                     threads,


### PR DESCRIPTION
- corrected extra iteration on main sieve
- added more cache-friendly `FlagStorageBitVectorStripedBlocks` version of the striped implementation
- simplified stripe/word accounting on `FlagStorageBitVectorStriped` based on learnings from the above
- basic tests added to validate storage directly

@Kulasko this might be of interest to you for your parallel implementations -- you could refactor this a bit and run the different blocks in parallel on different threads. 

It's a lot faster on the raspberri pi 4 as well -- I think it might be a bit quicker on your machine too.