### PR TITLE
Rust unrolled/experiment

### DIFF
--- a/PrimeRust/solution_1/.gitignore
+++ b/PrimeRust/solution_1/.gitignore
@@ -1,1 +1,2 @@
 target/
+perf*.data

--- a/PrimeRust/solution_1/Cargo.toml
+++ b/PrimeRust/solution_1/Cargo.toml
@@ -14,4 +14,4 @@ structopt = "0.3"
 opt-level = 3
 lto = true
 codegen-units = 1
-
+#debug = true

--- a/PrimeRust/solution_1/perf-collect
+++ b/PrimeRust/solution_1/perf-collect
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cargo build --release
+perf record target/release/prime-sieve-rust -t 1 --bits-unrolled -s 15

--- a/PrimeRust/solution_1/perf-report
+++ b/PrimeRust/solution_1/perf-report
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+perf report -M intel

--- a/PrimeRust/solution_1/src/flag_storage.rs
+++ b/PrimeRust/solution_1/src/flag_storage.rs
@@ -1,0 +1,12 @@
+/// Trait defining the interface to different kinds of storage, e.g.
+/// bits within bytes, a vector of bytes, etc.
+pub trait FlagStorage {
+    /// create new storage for given number of flags pre-initialised to all true
+    fn create_true(size: usize) -> Self;
+
+    /// reset all flags for the given `skip` factor (prime)
+    fn reset_flags(&mut self, skip: usize);
+
+    /// get a specific flag
+    fn get(&self, index: usize) -> bool;
+}

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -11,6 +11,8 @@ use std::{
 };
 use structopt::StructOpt;
 
+use crate::unrolled::FlagStorageUnrolledBits8;
+
 mod flag_storage;
 mod patterns;
 mod unrolled;
@@ -732,6 +734,11 @@ struct CommandLineOptions {
     #[structopt(long)]
     bits_striped_hybrid: bool,
 
+    /// Run variant that uses normal, linear bit-level storage, but uses a smarter
+    /// `unrolled` algorithm. Collaboration with @GordonBGood.
+    #[structopt(long)]
+    bits_unrolled: bool,
+
     /// Run variant that uses byte-level storage
     #[structopt(long)]
     bytes: bool,
@@ -758,6 +765,7 @@ fn main() {
         opt.bits_striped,
         opt.bits_striped_blocks,
         opt.bits_striped_hybrid,
+        opt.bits_unrolled,
         opt.bytes,
     ]
     .iter()
@@ -867,6 +875,21 @@ fn main() {
             for _ in 0..repetitions {
                 run_implementation::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL, true>>(
                     "bit-storage-striped-hybrid-small",
+                    1,
+                    run_duration,
+                    threads,
+                    limit,
+                    opt.print,
+                );
+            }
+        }
+
+        if opt.bits_unrolled || run_all {
+            thread::sleep(Duration::from_secs(1));
+            print_header(threads, limit, run_duration);
+            for _ in 0..repetitions {
+                run_implementation::<FlagStorageUnrolledBits8>(
+                    "bit-storage-unrolled8",
                     1,
                     run_duration,
                     threads,

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -898,16 +898,16 @@ fn main() {
                     opt.print,
                 );
             }
-            for _ in 0..repetitions {
-                run_implementation::<FlagStorageUnrolledBits32>(
-                    "bit-storage-unrolled32",
-                    1,
-                    run_duration,
-                    threads,
-                    limit,
-                    opt.print,
-                );
-            }
+            // for _ in 0..repetitions {
+            //     run_implementation::<FlagStorageUnrolledBits32>(
+            //         "bit-storage-unrolled32",
+            //         1,
+            //         run_duration,
+            //         threads,
+            //         limit,
+            //         opt.print,
+            //     );
+            // }
         }
     }
 }

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -11,11 +11,12 @@ use std::{
 };
 use structopt::StructOpt;
 
-use crate::unrolled::FlagStorageUnrolledBits8;
+use crate::{unrolled32::FlagStorageUnrolledBits32, unrolled8::FlagStorageUnrolledBits8};
 
 mod flag_storage;
 mod patterns;
-mod unrolled;
+mod unrolled8;
+mod unrolled32;
 
 
 pub mod primes {
@@ -897,6 +898,16 @@ fn main() {
                     opt.print,
                 );
             }
+            for _ in 0..repetitions {
+                run_implementation::<FlagStorageUnrolledBits32>(
+                    "bit-storage-unrolled32",
+                    1,
+                    run_duration,
+                    threads,
+                    limit,
+                    opt.print,
+                );
+            }
         }
     }
 }
@@ -974,7 +985,7 @@ fn run_implementation<T: 'static + FlagStorage + Send>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{flag_storage::FlagStorage, primes::{PrimeValidator, minimum_start, square_start}, unrolled::FlagStorageUnrolledBits8};
+    use crate::{flag_storage::FlagStorage, primes::{PrimeValidator, minimum_start, square_start}, unrolled32::FlagStorageUnrolledBits32, unrolled8::FlagStorageUnrolledBits8};
 
     #[test]
     fn sieve_known_correct_bits() {
@@ -1011,8 +1022,13 @@ mod tests {
     }
 
     #[test]
-    fn sieve_known_correct_unrolled_bits() {
+    fn sieve_known_correct_unrolled8_bits() {
         sieve_known_correct::<FlagStorageUnrolledBits8>();
+    }
+    
+    #[test]
+    fn sieve_known_correct_unrolled32_bits() {
+        sieve_known_correct::<FlagStorageUnrolledBits32>();
     }
 
     fn sieve_known_correct<T: FlagStorage>() {
@@ -1072,9 +1088,15 @@ mod tests {
     }
 
     #[test]
-    fn storage_bit_unrolled_correct() {
+    fn storage_bit_unrolled8_correct() {
         basic_storage_correct::<FlagStorageUnrolledBits8>();
     }
+
+    #[test]
+    fn storage_bit_unrolled32_correct() {
+        basic_storage_correct::<FlagStorageUnrolledBits32>();
+    }
+
 
     fn basic_storage_correct<T: FlagStorage>() {
         let size = 100_000;

--- a/PrimeRust/solution_1/src/patterns.rs
+++ b/PrimeRust/solution_1/src/patterns.rs
@@ -1,0 +1,131 @@
+pub const fn index_pattern<const BITS: usize>(skip: usize) -> [usize; BITS] {
+    let start = skip / 2;
+    let mut pattern = [0; BITS];
+    let mut i = 0;
+    while i < BITS {
+        let relative_index = start + i * skip;
+        pattern[i] = relative_index / BITS;
+        i += 1;
+    }
+    pattern
+}
+
+pub const fn modulo_pattern<const BITS: usize>(skip: usize) -> [usize; BITS] {
+    let start = skip / 2;
+    let mut pattern = [0; BITS];
+    let mut i = 0;
+    while i < BITS {
+        let relative_index = start + i * skip;
+        pattern[i] = relative_index % BITS;
+        i += 1;
+    }
+    pattern
+}
+
+pub const fn modulo_pattern_sets<const BITS: usize>() -> [[usize; BITS]; BITS] {
+    let first = 3;
+    let mut pattern_sets = [[0; BITS]; BITS];
+    let mut i = 0;
+    while i < BITS {
+        let skip = first + i * 2;
+        pattern_sets[i] = modulo_pattern(skip);
+        i += 1;
+    }
+    pattern_sets
+}
+
+// TODO: generic over type, possibly, to generalise to u32
+pub const fn mask_pattern_sets_u8() -> [[u8; 8]; 8] {
+    let mut mask_sets = [[0; 8]; 8];
+    let mut i = 0;
+    while i < 8 {
+        let mut j = 0;
+        while j < 8 {
+            mask_sets[i][j] = 1 << BIT_PATTERNS_U8[i][j];
+            j += 1;
+        }
+        i += 1;
+    }
+    mask_sets
+}
+
+pub const BIT_PATTERNS_U8: [[usize; 8]; 8] = modulo_pattern_sets::<8>();
+pub const MASK_PATTERNS_U8: [[u8; 8]; 8] = mask_pattern_sets_u8();
+
+pub const BIT_PATTERNS_U32: [[usize; 32]; 32] = modulo_pattern_sets::<32>();
+
+#[cfg(test)]
+mod tests {
+    use crate::patterns::{index_pattern, BIT_PATTERNS_U32, BIT_PATTERNS_U8, MASK_PATTERNS_U8};
+
+    #[test]
+    fn modulo_pattern_set_u8_correct() {
+        assert_eq!(BIT_PATTERNS_U8[0], [1, 4, 7, 2, 5, 0, 3, 6]);
+        assert_eq!(BIT_PATTERNS_U8[1], [2, 7, 4, 1, 6, 3, 0, 5]);
+        assert_eq!(BIT_PATTERNS_U8[7], [0, 1, 2, 3, 4, 5, 6, 7]);
+    }
+
+    #[test]
+    fn mask_pattern_set_u8_correct() {
+        let expected: Vec<u8> = [1, 4, 7, 2, 5, 0, 3, 6].iter().map(|b| 1 << b).collect();
+        assert_eq!(MASK_PATTERNS_U8[0][..], expected[..]);
+    }
+
+    #[test]
+    fn modulo_pattern_set_u32_correct() {
+        assert_eq!(
+            BIT_PATTERNS_U32[0],
+            [
+                1, 4, 7, 10, 13, 16, 19, 22, 25, 28, 31, 2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 0, 3,
+                6, 9, 12, 15, 18, 21, 24, 27, 30
+            ]
+        );
+        assert_eq!(
+            BIT_PATTERNS_U32[1],
+            [
+                2, 7, 12, 17, 22, 27, 0, 5, 10, 15, 20, 25, 30, 3, 8, 13, 18, 23, 28, 1, 6, 11, 16,
+                21, 26, 31, 4, 9, 14, 19, 24, 29
+            ]
+        );
+        assert_eq!(
+            BIT_PATTERNS_U32[31],
+            [
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
+                23, 24, 25, 26, 27, 28, 29, 30, 31
+            ]
+        );
+    }
+
+    #[test]
+    fn index_pattern_set_u8_correct() {
+        assert_eq!(index_pattern::<8>(3), [0, 0, 0, 1, 1, 2, 2, 2]);
+        assert_eq!(index_pattern::<8>(5), [0, 0, 1, 2, 2, 3, 4, 4]);
+        assert_eq!(index_pattern::<8>(17), [1, 3, 5, 7, 9, 11, 13, 15]);
+        assert_eq!(index_pattern::<8>(51), [3, 9, 15, 22, 28, 35, 41, 47,]);
+    }
+
+    #[test]
+    fn index_pattern_set_u32_correct() {
+        assert_eq!(
+            index_pattern::<32>(3),
+            [
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2,
+                2, 2, 2, 2,
+            ]
+        );
+        assert_eq!(
+            index_pattern::<32>(5),
+            [
+                0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4,
+                4, 4, 4, 4,
+            ]
+        );
+        assert_eq!(
+            index_pattern::<32>(51),
+            [
+                0, 2, 3, 5, 7, 8, 10, 11, 13, 15, 16, 18, 19, 21, 23, 24, 26, 27, 29, 31, 32, 34,
+                35, 37, 39, 40, 42, 43, 45, 47, 48, 50,
+            ]
+        )
+    }
+}

--- a/PrimeRust/solution_1/src/patterns.rs
+++ b/PrimeRust/solution_1/src/patterns.rs
@@ -49,10 +49,26 @@ pub const fn mask_pattern_sets_u8() -> [[u8; 8]; 8] {
     mask_sets
 }
 
+// TODO: generic over type (as above)
+pub const fn mask_pattern_sets_u32() -> [[u32; 32]; 32] {
+    let mut mask_sets = [[0; 32]; 32];
+    let mut i = 0;
+    while i < 32 {
+        let mut j = 0;
+        while j < 32 {
+            mask_sets[i][j] = 1 << BIT_PATTERNS_U32[i][j];
+            j += 1;
+        }
+        i += 1;
+    }
+    mask_sets
+}
+
 pub const BIT_PATTERNS_U8: [[usize; 8]; 8] = modulo_pattern_sets::<8>();
 pub const MASK_PATTERNS_U8: [[u8; 8]; 8] = mask_pattern_sets_u8();
 
 pub const BIT_PATTERNS_U32: [[usize; 32]; 32] = modulo_pattern_sets::<32>();
+pub const MASK_PATTERNS_U32: [[u32; 32]; 32] = mask_pattern_sets_u32();
 
 #[cfg(test)]
 mod tests {

--- a/PrimeRust/solution_1/src/unrolled.rs
+++ b/PrimeRust/solution_1/src/unrolled.rs
@@ -1,0 +1,145 @@
+use crate::{flag_storage::FlagStorage, patterns::{MASK_PATTERNS_U8, index_pattern}};
+
+
+pub struct FlagStorageUnrolledBits8 {
+    words: Vec<u8>,
+    length_bits: usize,
+}
+
+impl FlagStorageUnrolledBits8 {
+    const BITS: usize = u8::BITS as usize;
+
+    fn reset_flags_sparse(&mut self, skip: usize) {
+        let mask_set_index = ((skip / 2) - 1) % Self::BITS;
+        let mask_set = MASK_PATTERNS_U8[mask_set_index];
+
+        let rel_indices = index_pattern::<8>(skip);
+
+        self.words.chunks_exact_mut(skip).for_each(|chunk| {
+            for i in 0..Self::BITS {
+                let word_idx = rel_indices[i];
+                chunk[word_idx] |= mask_set[i];
+            }
+        });
+
+        let remainder = self.words.chunks_exact_mut(skip).into_remainder();
+        for i in 0..Self::BITS {
+            let word_idx = rel_indices[i];
+            if word_idx < remainder.len() {
+                remainder[word_idx] |= mask_set[i];
+            } else {
+                break;
+            }
+        }
+
+        // restore original factor bit -- we have clobbered it, and it is the prime
+        let factor_index = skip / 2;
+        let factor_word = factor_index / Self::BITS;
+        let factor_bit = factor_index % Self::BITS;
+        if let Some(w) = self.words.get_mut(factor_word) {
+            *w &= !(1 << factor_bit);
+        }
+    }
+
+    fn reset_flags_dense<const SKIP: usize>(&mut self) {
+        let mask_set_index = ((SKIP / 2) - 1) % Self::BITS;
+        let mask_set = MASK_PATTERNS_U8[mask_set_index];
+
+        let rel_indices = index_pattern::<8>(SKIP);
+
+        self.words.chunks_exact_mut(SKIP).for_each(|chunk| {
+            for i in 0..Self::BITS {
+                let word_idx = rel_indices[i];
+                chunk[word_idx] |= mask_set[i];
+            }
+        });
+
+        let remainder = self.words.chunks_exact_mut(SKIP).into_remainder();
+        for i in 0..Self::BITS {
+            let word_idx = rel_indices[i];
+            if word_idx < remainder.len() {
+                remainder[word_idx] |= mask_set[i];
+            } else {
+                break;
+            }
+        }
+
+        // restore original factor bit -- we have clobbered it, and it is the prime
+        let factor_index = SKIP / 2;
+        let factor_word = factor_index / Self::BITS;
+        let factor_bit = factor_index % Self::BITS;
+        if let Some(w) = self.words.get_mut(factor_word) {
+            *w &= !(1 << factor_bit);
+        }
+    }
+
+    fn print(&self, limit: usize) {
+        println!("Storage----");
+        for (i, w) in self.words.iter().take(limit).enumerate() {
+            println!("{:6}: {}", i, format_bits(*w));
+        }
+        let last_idx = self.words.len() - 1;
+        let last_word = self.words[last_idx];
+        println!("{:6}: {}", last_idx, format_bits(last_word));
+    }
+}
+
+impl FlagStorage for FlagStorageUnrolledBits8 {
+    fn create_true(size: usize) -> Self {
+        let num_words = size / Self::BITS + (size % Self::BITS).min(1);
+        Self {
+            words: vec![0; num_words],
+            length_bits: size,
+        }
+    }
+
+    fn reset_flags(&mut self, skip: usize) {
+        // call into dispatcher
+        // TODO: autogenerate match_reset_dispatch!(self, skip, 19, reset_flags_dense, reset_flags_sparse);
+        match skip {
+            3 => self.reset_flags_dense::<3>(),
+            5 => self.reset_flags_dense::<5>(),
+            7 => self.reset_flags_dense::<7>(),
+            9 => self.reset_flags_dense::<9>(),
+            11 => self.reset_flags_dense::<11>(),
+            13 => self.reset_flags_dense::<13>(),
+            15 => self.reset_flags_dense::<15>(),
+            17 => self.reset_flags_dense::<17>(),
+            19 => self.reset_flags_dense::<19>(),
+            _ => self.reset_flags_sparse(skip)
+        };
+    }
+
+    fn get(&self, index: usize) -> bool {
+        if index >= self.length_bits {
+            return false;
+        }
+        let word = self.words.get(index / Self::BITS).unwrap();
+        *word & (1 << (index % Self::BITS)) == 0
+    }
+}
+
+fn format_bits(val: u8) -> String {
+    let bits = (0..8)
+        .map(|b| (val & (1 << b)) >> b)
+        .map(|b| format!("{} ", b));
+    bits.collect()
+}
+
+pub fn self_test() {
+    let size = 512;
+    self_test_specific(3, size);
+    self_test_specific(5, size);
+    self_test_specific(7, size);
+    self_test_specific(63, size);
+    self_test_specific(1001, size);
+    self_test_specific(2000, size);
+}
+
+fn self_test_specific(skip: usize, size: usize) {
+    let mut storage = FlagStorageUnrolledBits8::create_true(size);
+    let lim = 16;
+    println!("Testing with skip = {}", skip);
+    storage.reset_flags(skip);
+    storage.print(lim);
+}

--- a/PrimeRust/solution_1/src/unrolled8.rs
+++ b/PrimeRust/solution_1/src/unrolled8.rs
@@ -11,6 +11,7 @@ pub struct FlagStorageUnrolledBits8 {
 impl FlagStorageUnrolledBits8 {
     const BITS: usize = u8::BITS as usize;
 
+    // inline, since it's always the same
     #[inline(always)]
     fn reset_flags_sparse(&mut self, skip: usize) {
         let mask_set_index = ((skip / 2) - 1) % Self::BITS;
@@ -50,7 +51,9 @@ impl FlagStorageUnrolledBits8 {
         }
     }
 
-    #[inline(always)]
+    // rather do a function call; we'll have more registers available, and it's
+    // not called very often
+    #[inline(never)]
     fn reset_flags_dense<const SKIP: usize>(&mut self) {
         let mask_set_index = ((SKIP / 2) - 1) % Self::BITS;
         let mask_set = MASK_PATTERNS_U8[mask_set_index];

--- a/PrimeRust/solution_1/src/unrolled8.rs
+++ b/PrimeRust/solution_1/src/unrolled8.rs
@@ -1,0 +1,128 @@
+use crate::{
+    flag_storage::FlagStorage,
+    patterns::{index_pattern, MASK_PATTERNS_U8},
+};
+
+pub struct FlagStorageUnrolledBits8 {
+    words: Vec<u8>,
+    length_bits: usize,
+}
+
+impl FlagStorageUnrolledBits8 {
+    const BITS: usize = u8::BITS as usize;
+
+    #[inline(always)]
+    fn reset_flags_sparse(&mut self, skip: usize) {
+        let mask_set_index = ((skip / 2) - 1) % Self::BITS;
+        let mask_set = MASK_PATTERNS_U8[mask_set_index];
+
+        let rel_indices = index_pattern::<8>(skip);
+
+        self.words.chunks_exact_mut(skip).for_each(|chunk| {
+            for i in 0..Self::BITS {
+                let word_idx = rel_indices[i];
+                // TODO: safety note
+                unsafe {
+                    *chunk.get_unchecked_mut(word_idx) |= mask_set[i];
+                }
+            }
+        });
+
+        let remainder = self.words.chunks_exact_mut(skip).into_remainder();
+        for i in 0..Self::BITS {
+            let word_idx = rel_indices[i];
+            if word_idx < remainder.len() {
+                // TODO: safety note
+                unsafe {
+                    *remainder.get_unchecked_mut(word_idx) |= mask_set[i];
+                }
+            } else {
+                break;
+            }
+        }
+
+        // restore original factor bit -- we have clobbered it, and it is the prime
+        let factor_index = skip / 2;
+        let factor_word = factor_index / Self::BITS;
+        let factor_bit = factor_index % Self::BITS;
+        if let Some(w) = self.words.get_mut(factor_word) {
+            *w &= !(1 << factor_bit);
+        }
+    }
+
+    #[inline(always)]
+    fn reset_flags_dense<const SKIP: usize>(&mut self) {
+        let mask_set_index = ((SKIP / 2) - 1) % Self::BITS;
+        let mask_set = MASK_PATTERNS_U8[mask_set_index];
+
+        let rel_indices = index_pattern::<8>(SKIP);
+
+        self.words.chunks_exact_mut(SKIP).for_each(|chunk| {
+            for i in 0..Self::BITS {
+                let word_idx = rel_indices[i];
+                // TODO: safety note
+                unsafe {
+                    *chunk.get_unchecked_mut(word_idx) |= mask_set[i];
+                }
+            }
+        });
+
+        let remainder = self.words.chunks_exact_mut(SKIP).into_remainder();
+        for i in 0..Self::BITS {
+            let word_idx = rel_indices[i];
+            if word_idx < remainder.len() {
+                // TODO: safety note
+                unsafe {
+                    *remainder.get_unchecked_mut(word_idx) |= mask_set[i];
+                }
+            } else {
+                break;
+            }
+        }
+
+        // restore original factor bit -- we have clobbered it, and it is the prime
+        let factor_index = SKIP / 2;
+        let factor_word = factor_index / Self::BITS;
+        let factor_bit = factor_index % Self::BITS;
+        if let Some(w) = self.words.get_mut(factor_word) {
+            *w &= !(1 << factor_bit);
+        }
+    }
+}
+
+impl FlagStorage for FlagStorageUnrolledBits8 {
+    fn create_true(size: usize) -> Self {
+        let num_words = size / Self::BITS + (size % Self::BITS).min(1);
+        Self {
+            words: vec![0; num_words],
+            length_bits: size,
+        }
+    }
+
+    #[inline(always)]
+    fn reset_flags(&mut self, skip: usize) {
+        // call into dispatcher
+        // TODO: autogenerate match_reset_dispatch!(self, skip, 19, reset_flags_dense, reset_flags_sparse);
+        match skip {
+            3 => self.reset_flags_dense::<3>(),
+            5 => self.reset_flags_dense::<5>(),
+            7 => self.reset_flags_dense::<7>(),
+            9 => self.reset_flags_dense::<9>(),
+            11 => self.reset_flags_dense::<11>(),
+            // 13 => self.reset_flags_dense::<13>(),
+            // 15 => self.reset_flags_dense::<15>(),
+            // 17 => self.reset_flags_dense::<17>(),
+            // 19 => self.reset_flags_dense::<19>(),
+            _ => self.reset_flags_sparse(skip),
+        };
+    }
+
+    #[inline(always)]
+    fn get(&self, index: usize) -> bool {
+        if index >= self.length_bits {
+            return false;
+        }
+        let word = self.words.get(index / Self::BITS).unwrap();
+        *word & (1 << (index % Self::BITS)) == 0
+    }
+}


### PR DESCRIPTION
@GordonBGood, here's the first cut :) It's working, but not working very well just yet.

Some issues to resolve still: in particular, the unrolled indices are not getting pulled in as constants yet, so the compiler isn't able to coalesce these operations on the same word into a single load, or, or, or, store. I'm fighting with the compiler a bit.

So far I haven't had to resort to procedural macros, but that will be the next step if I can't find a workaround to the above problem. I discovered it's going to be a little messy in the context of my existing solution because they'll need to reside in a separate crate, and I'll need to move the whole project structure around to accommodate it. 

The other relevant issue is that I probably should be using specific reset functions for the sparse resets too. And I'll need to fix the above problem to get that working correctly too. Right now I'm just using a generalised sparse reset function.

Considering the above issues still to be resolved, the performance is looking pretty good: around 22k iterations on the 8b implementation. There's light at the end of the tunnel :)

I really like your Chapel implementation. Especially using the 64b words for the dense part, but retaining the 8b version for the sparse resets :) That is a very neat idea. And it's fast as anything on my machine -- nearly 30k iterations vs. about 25k for my existing striped blocks hybrid.



